### PR TITLE
Add lintian_check and fail_on_lintian_error options

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,11 @@
-1.1.0 (2014-12-12)
+1.2.0 (2026-04-13)
+------------------
+  * Added lintian_check option to run lintian on the built package
+  * Added fail_on_lintian_error option to control whether a lintian failure
+    fails the action (default: true, only applies when lintian_check is true)
+  * Added lintian to the Docker image
+
+1.1.0 (2024-12-12)
 ------------------
   * Added support for building trixie packages
   * Fixed passing multiple args (Thanks @ehbello)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN \
     build-essential \
     debhelper \
     devscripts \
-    equivs && \
+    equivs \
+    lintian && \
     if [ "$CODENAME" = "bookworm" ]; then \
       apt install -y software-properties-common; \
     fi

--- a/README.md
+++ b/README.md
@@ -90,12 +90,20 @@ jobs:
     required: false
   codename:
     description: 'Debian codename'
-    reqired: false
+    required: false
     default: 'bookworm'
   platform:
     description: 'Target architecture'
     required: false
     default: 'amd64'
+  lintian_check:
+    description: 'Run lintian on the built package'
+    required: false
+    default: 'false'
+  fail_on_lintian_error:
+    description: 'Fail the action if lintian reports errors (only applies when lintian_check is true)'
+    required: false
+    default: 'true'
 ```
 
 ## Related actions

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: 'Target architecture'
     required: false
     default: 'amd64'
+  lintian_check:
+    description: 'Run lintian on the built package'
+    required: false
+    default: 'false'
+  fail_on_lintian_error:
+    description: 'Fail the action if lintian reports errors (only applies when lintian_check is true)'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -38,6 +46,8 @@ runs:
           -e INPUT_SOURCES="${{ inputs.sources }}" \
           -e INPUT_PPA="${{ inputs.ppa }}" \
           -e INPUT_ARGS="${{ inputs.args }}" \
+          -e INPUT_LINTIAN_CHECK="${{ inputs.lintian_check }}" \
+          -e INPUT_FAIL_ON_LINTIAN_ERROR="${{ inputs.fail_on_lintian_error }}" \
           ghcr.io/andy5995/gh-action-build-deb:$CODENAME
       shell: bash
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,16 @@ dpkg-buildpackage $INPUT_ARGS
 # Output the filename
 cd ..
 ls -l
+
+if [ "$INPUT_LINTIAN_CHECK" = "true" ]; then
+    lintian_exit_code=0
+    lintian *.changes || lintian_exit_code=$?
+    if [ "$INPUT_FAIL_ON_LINTIAN_ERROR" != "false" ] && [ "$lintian_exit_code" -ne 0 ]; then
+        echo "lintian check failed (exit code $lintian_exit_code)"
+        exit "$lintian_exit_code"
+    fi
+fi
+
 mkdir -p /workspace/output/
 # Move the built package into the Docker mounted workspace
 mv -v *.{deb,dsc,changes,buildinfo,tar.*} /workspace/output/


### PR DESCRIPTION
Install lintian in the Docker image and run it against the built .changes file when lintian_check is set to true. The fail_on_lintian_error option (default: true) controls whether a non-zero lintian exit code fails the action.