### PR TITLE
Fix running dpkg as root

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/gh-action-build-deb
+  # Bump this when cutting a new major release so old images remain available.
+  MAJOR_VERSION: v1
 
 jobs:
   build:
@@ -127,6 +129,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ matrix.codename == 'trixie' }}
             type=raw,value=${{ matrix.codename }}
+            type=raw,value=${{ matrix.codename }}-${{ env.MAJOR_VERSION }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ACTION_DIR: '_action_test'
+      # Keep in sync with docker.yml MAJOR_VERSION when cutting a major release.
+      MAJOR_VERSION: v1
     steps:
     - name: Prepare
       run: |
@@ -89,7 +91,7 @@ jobs:
           . \
           --build-arg CODENAME=${{ matrix.codename }} \
           --platform linux/${{ matrix.platform }} \
-          -t ghcr.io/${{ github.repository_owner }}/gh-action-build-deb:${{ matrix.codename }} \
+          -t ghcr.io/${{ github.repository_owner }}/gh-action-build-deb:${{ matrix.codename }}-${{ env.MAJOR_VERSION }} \
           --cache-to=type=local,dest=${{ env.DOCKER_CACHE_DEST }} \
           --cache-from=type=local,src=${{ env.DOCKER_CACHE_DEST }} \
           --load

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,8 @@ jobs:
         args: |
           --no-sign
           --compression=xz
+        lintian_check: true
+        fail_on_lintian_error: false
         platform: ${{ matrix.platform }}
 
     - name: Create sha256sum

--- a/Changelog
+++ b/Changelog
@@ -1,9 +1,11 @@
-1.2.0 (2026-04-13)
+
+gh-action-build-deb (in-progress):
 ------------------
+  * Fix running dpkg as root
+  * Added lintian to the Docker image
   * Added lintian_check option to run lintian on the built package
   * Added fail_on_lintian_error option to control whether a lintian failure
     fails the action (default: true, only applies when lintian_check is true)
-  * Added lintian to the Docker image
 
 1.1.0 (2024-12-12)
 ------------------

--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,8 @@ gh-action-build-deb (in-progress):
   * Added lintian_check option to run lintian on the built package
   * Added fail_on_lintian_error option to control whether a lintian failure
     fails the action (default: true, only applies when lintian_check is true)
+  * Include major version in Docker image tags (e.g. bookworm-v1) so images
+    from prior major releases remain available after a version bump
 
 1.1.0 (2024-12-12)
 ------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN \
 
 RUN sed -i 's/Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/debian.sources
 
+RUN useradd -m builder && passwd -d builder
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
           -e INPUT_ARGS="${{ inputs.args }}" \
           -e INPUT_LINTIAN_CHECK="${{ inputs.lintian_check }}" \
           -e INPUT_FAIL_ON_LINTIAN_ERROR="${{ inputs.fail_on_lintian_error }}" \
-          ghcr.io/andy5995/gh-action-build-deb:$CODENAME
+          ghcr.io/andy5995/gh-action-build-deb:${CODENAME}-v1
       shell: bash
 
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,23 +22,37 @@ if [ -n "$INPUT_PPA" ]; then
     fi
 fi
 
+# Normalize INPUT_ARGS: users may supply a multiline YAML block scalar, which
+# embeds newlines. Collapse them to spaces so the args stay on one line when
+# expanded inside the bash -c string passed to dpkg-buildpackage.
+INPUT_ARGS="${INPUT_ARGS//$'\n'/ }"
+
 apt update && apt upgrade -y
 
 # Set the install command to be used by mk-build-deps (use --yes for non-interactive)
 install_tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes"
 # Install build dependencies automatically
-mk-build-deps --install --tool="${install_tool}" debian/control
-# First build the source package
-dpkg-buildpackage --build=source $INPUT_ARGS
-# Then a normal build
-dpkg-buildpackage $INPUT_ARGS
-# Output the filename
-cd ..
-ls -l
+mk-build-deps -i -r --tool="${install_tool}" debian/control
 
+# dpkg-buildpackage writes output files (*.deb, *.changes, etc.) to the
+# parent of the source directory. Copy the source into a staging area
+# owned by builder so both the source dir and its parent are writable.
+STAGING=$(mktemp -d /tmp/deb-build.XXXXXX)
+SRC_COPY="$STAGING/$(basename "$PWD")"
+cp -a "$PWD/." "$SRC_COPY"
+chown -R builder:builder "$STAGING"
+
+runuser -u builder -- bash -c "
+  cd '$SRC_COPY' &&
+  dpkg-buildpackage -rfakeroot $INPUT_ARGS
+"
+
+ls -l "$STAGING"
+
+lintian_exit_code=0
 if [ "$INPUT_LINTIAN_CHECK" = "true" ]; then
-    lintian_exit_code=0
-    lintian *.changes || lintian_exit_code=$?
+    CHANGES=$(ls "$STAGING"/*.changes | head -n1)
+    runuser -u builder -- lintian "$CHANGES" || lintian_exit_code=$?
     if [ "$INPUT_FAIL_ON_LINTIAN_ERROR" != "false" ] && [ "$lintian_exit_code" -ne 0 ]; then
         echo "lintian check failed (exit code $lintian_exit_code)"
         exit "$lintian_exit_code"
@@ -46,5 +60,8 @@ if [ "$INPUT_LINTIAN_CHECK" = "true" ]; then
 fi
 
 mkdir -p /workspace/output/
-# Move the built package into the Docker mounted workspace
-mv -v *.{deb,dsc,changes,buildinfo,tar.*} /workspace/output/
+# Move the built packages into the Docker mounted workspace
+for f in "$STAGING"/*.deb "$STAGING"/*.dsc "$STAGING"/*.changes \
+         "$STAGING"/*.buildinfo "$STAGING"/*.tar.*; do
+    [ -f "$f" ] && mv -v "$f" /workspace/output/
+done


### PR DESCRIPTION
Copy source to a builder-owned staging dir before running dpkg-buildpackage, so it can write output files to its parent directory without a permission denied error. Run dpkg-buildpackage and lintian via runuser so neither runs as root.